### PR TITLE
fix(ci): resolve analyzer conflict in preview integration

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           cat > pubspec_overrides.yaml <<'EOF'
           dependency_overrides:
+            analyzer: ^7.4.0
             tdesign_flutter_tools:
               path: ../../
           EOF


### PR DESCRIPTION
## 问题

预览 CI 克隆 Tencent/tdesign-flutter 的 develop，该分支仍声明 analyzer ^6.11.0；本仓库 tools 已升级到 analyzer ^7.4.0。通过 path override 接入 tools 后，Pub 解析失败。

## 修复

在预览构建生成的 pubspec_overrides.yaml 中同时覆盖 analyzer 到 ^7.4.0。该覆盖仅作用于 CI 临时工作树，不修改 tdesign-flutter 源码；待组件仓库升级 analyzer 后仍可正常工作。

## 验证

使用 Tencent/tdesign-flutter develop 快照和 Flutter 3.32.0 复现 CI：flutter pub get 成功，analyzer 7.7.1 与 path tools 均正确生效。